### PR TITLE
US601024: Bring Java Adapter SDK back into sync with .NET version

### DIFF
--- a/src/main/java/io/github/fileanalysissuite/adaptersdk/interfaces/extensibility/RepositoryAdapter.java
+++ b/src/main/java/io/github/fileanalysissuite/adaptersdk/interfaces/extensibility/RepositoryAdapter.java
@@ -19,7 +19,7 @@ import io.github.fileanalysissuite.adaptersdk.interfaces.framework.CancellationT
 import io.github.fileanalysissuite.adaptersdk.interfaces.framework.FileDataResultsHandler;
 import io.github.fileanalysissuite.adaptersdk.interfaces.framework.FileListResultsHandler;
 import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RetrieveFileListRequest;
-import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RetrieveFilesDataRequest;
+import io.github.fileanalysissuite.adaptersdk.interfaces.framework.RepositoryFilesRequest;
 import javax.annotation.Nonnull;
 
 /**
@@ -56,5 +56,5 @@ public interface RepositoryAdapter
      * @param handler the handler
      * @param cancellationToken the cancellation token that can be used by other objects or threads to receive notice of cancellation
      */
-    void retrieveFilesData(RetrieveFilesDataRequest request, FileDataResultsHandler handler, CancellationToken cancellationToken);
+    void retrieveFilesData(RepositoryFilesRequest request, FileDataResultsHandler handler, CancellationToken cancellationToken);
 }

--- a/src/main/java/io/github/fileanalysissuite/adaptersdk/interfaces/framework/RepositoryFilesRequest.java
+++ b/src/main/java/io/github/fileanalysissuite/adaptersdk/interfaces/framework/RepositoryFilesRequest.java
@@ -24,7 +24,7 @@ import javax.annotation.Nonnull;
  * File data retrieval is a part of the process of scanning repository. When the adapter receives that RetrieveFilesData command
  * ({@link RepositoryAdapter#retrieveFilesData} method), it should queue the binary contents and expensive metadata.
  */
-public interface RetrieveFilesDataRequest extends HandlerRequest
+public interface RepositoryFilesRequest extends HandlerRequest
 {
     /**
      * Returns the list of files to retrieve.


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=601024

Renamed RetrieveFilesDataRequest to RepositoryFilesRequest, to be in sync with the changes in .NET Adapter SDK code.